### PR TITLE
[PoC] Interop with ES Observable spec draft

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "reactive",
     "dynamic"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "symbol-observable": "^1.0.1"
+  },
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-preset-es2015": "^6.6.0",
@@ -50,6 +52,7 @@
     "mocha": "^2.2.5",
     "mocha-istanbul": "^0.2.0",
     "rollup": "^0.26.1",
+    "rxjs": "^5.0.0-beta.10",
     "source-map-support": "^0.3.2",
     "uglify-js": "^2.4.24"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {derivablePrototype} from './derivable';
 import {mutablePrototype} from './mutable';
+import {observablePrototype} from './observable';
 import {Derivation} from './derivation';
 import {Lens} from './lens';
 import {Atom} from './atom';
@@ -7,9 +8,9 @@ import {assign} from './util';
 
 import * as derivable from './module';
 
-assign(Derivation.prototype, derivablePrototype);
-assign(Lens.prototype, derivablePrototype, mutablePrototype);
-assign(Atom.prototype, derivablePrototype, mutablePrototype);
+assign(Derivation.prototype, derivablePrototype, observablePrototype);
+assign(Lens.prototype, derivablePrototype, observablePrototype, mutablePrototype);
+assign(Atom.prototype, derivablePrototype, observablePrototype, mutablePrototype);
 
 
 export var __Reactor = derivable.__Reactor;

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,0 +1,29 @@
+import $$observable from 'symbol-observable'
+import {Reactor} from './reactors';
+
+export var observablePrototype = {};
+
+observablePrototype[$$observable] = function() {
+  var value = this;
+
+  return {
+    subscribe: function(observer) {
+      function pushNext(value) {
+        if (observer.next) {
+          observer.next(value);
+        }
+      }
+
+      pushNext(value.get());
+
+      var reactor = new Reactor(value, pushNext);
+      reactor.start();
+
+      return {
+        unsubscribe: function() {
+          reactor.stop();
+        }
+      };
+    }
+  };
+};

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,13 @@
 export var keys = Object.keys;
+export var symbols = Object.getOwnPropertySymbols;
 
 export function assign (obj) {
   for (var i = 1; i < arguments.length; i++) {
-    var other = arguments[i];
-    var ks = keys(other || {});
+    var other = arguments[i] || {};
+    var ks = keys(other);
+    if (symbols) {
+      ks = ks.concat(symbols(other));
+    }
     for (var j = ks.length; j--;) {
       var prop = ks[j];
       obj[prop] = other[prop];

--- a/test/atom_test.js
+++ b/test/atom_test.js
@@ -1,93 +1,88 @@
 'use strict';
 
-var _immutable = require('immutable');
-
-var _immutable2 = _interopRequireDefault(_immutable);
-
-var _derivable = require('../dist/derivable');
-
-var _derivable2 = _interopRequireDefault(_derivable);
-
-var _assert = require('assert');
-
-var _assert2 = _interopRequireDefault(_assert);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+var derivable = require('../dist/derivable');
+var assert = require('assert');
 
 describe("the humble atom", function () {
-  var n = (0, _derivable.atom)(0);
+
+  var n;
+
+  beforeEach(function() {
+    n = derivable.atom(0);
+  });
 
   it("can be dereferenced via .get to obtain its current state", function () {
-    _assert2.default.strictEqual(n.get(), 0);
+    assert.strictEqual(n.get(), 0);
   });
 
   it("can be .set to change its current state", function () {
     n.set(1);
-    _assert2.default.strictEqual(n.get(), 1);
+    assert.strictEqual(n.get(), 1);
   });
 
   it("can be .swap-ped a la clojure", function () {
+    n.set(1);
     var double = function double(x) {
       return x * 2;
     };
     n.swap(double);
-    _assert2.default.strictEqual(n.get(), 2);
+    assert.strictEqual(n.get(), 2);
     n.swap(double);
-    _assert2.default.strictEqual(n.get(), 4);
+    assert.strictEqual(n.get(), 4);
   });
 
   it('can take on temporary values inside a transaction', function () {
-    var a = (0, _derivable.atom)("a");
-    (0, _derivable.transact)(function (abort) {
+    var a = derivable.atom("a");
+    derivable.transact(function (abort) {
       a.set("b");
-      _assert2.default.strictEqual(a.get(), "b", "blah and junk");
-      (0, _derivable.transact)(function (abort) {
+      assert.strictEqual(a.get(), "b", "blah and junk");
+      derivable.transact(function (abort) {
         a.set("c");
-        _assert2.default.strictEqual(a.get(), "c");
+        assert.strictEqual(a.get(), "c");
         abort();
       });
-      _assert2.default.strictEqual(a.get(), "b");
+      assert.strictEqual(a.get(), "b");
       abort();
     });
-    _assert2.default.strictEqual(a.get(), "a");
+    assert.strictEqual(a.get(), "a");
   });
 
   it('should be able to go back to its original value with no ill effects', function () {
-    var a = _derivable.atom("a");
+    var a = derivable.atom("a");
     var reacted = false;
     a.react(function () {
       reacted = true;
     }, {skipFirst: true});
 
-    _assert.strictEqual(reacted, false, "no reaction to begin with");
+    assert.strictEqual(reacted, false, "no reaction to begin with");
 
-    _derivable.transact(function () {
+    derivable.transact(function () {
       a.set("b");
       a.set("a");
     });
 
-    _assert.strictEqual(reacted, false, "no reaction should take place");
+    assert.strictEqual(reacted, false, "no reaction should take place");
   });
 
   it('can keep transaction values if they are\'t aborted', function () {
-    var a = (0, _derivable.atom)("a");
-    (0, _derivable.transact)(function () {
+    var a = derivable.atom("a");
+    derivable.transact(function () {
       a.set("b");
-      (0, _derivable.transact)(function () {
+      derivable.transact(function () {
         a.set("c");
       });
-      _assert2.default.strictEqual(a.get(), "c");
+      assert.strictEqual(a.get(), "c");
     });
-    _assert2.default.strictEqual(a.get(), "c");
+    assert.strictEqual(a.get(), "c");
   });
 
   it('can include an equality-checking function', function () {
-    var a = (0, _derivable.atom)(0);
+    var a = derivable.atom(0);
     var b = a.withEquality(function () {
       return false;
     });
     it('creates a brand new atom', function () {
-      (0, _assert2.default)(a !== b);
+      assert(a !== b);
     });
 
     var numReactions = 0;
@@ -98,36 +93,36 @@ describe("the humble atom", function () {
       return numReactions++;
     }, { skipFirst: true });
 
-    _assert2.default.strictEqual(numReactions, 0, "0 a");
+    assert.strictEqual(numReactions, 0, "0 a");
     a.set(0);
-    _assert2.default.strictEqual(numReactions, 0, "0 b");
+    assert.strictEqual(numReactions, 0, "0 b");
     a.set(0);
-    _assert2.default.strictEqual(numReactions, 0, "0 c");
+    assert.strictEqual(numReactions, 0, "0 c");
 
     b.set(0);
-    _assert2.default.strictEqual(numReactions, 1, "0 d");
+    assert.strictEqual(numReactions, 1, "0 d");
     b.set(0);
-    _assert2.default.strictEqual(numReactions, 2, "0 e");
+    assert.strictEqual(numReactions, 2, "0 e");
   });
 
   it('only likes functions or falsey things for equality functions', function () {
-    (0, _derivable.atom)(4).withEquality('');
-    _assert2.default.throws(function () {
-      (0, _derivable.atom)(4).withEquality('yo');
+    derivable.atom(4).withEquality('');
+    assert.throws(function () {
+      derivable.atom(4).withEquality('yo');
     });
-    (0, _derivable.atom)(4).withEquality(0);
-    _assert2.default.throws(function () {
-      (0, _derivable.atom)(4).withEquality(7);
+    derivable.atom(4).withEquality(0);
+    assert.throws(function () {
+      derivable.atom(4).withEquality(7);
     });
-    (0, _derivable.atom)(4).withEquality(null);
-    (0, _derivable.atom)(4).withEquality(void 0);
+    derivable.atom(4).withEquality(null);
+    derivable.atom(4).withEquality(void 0);
   });
 });
 
 describe('the concurrent modification of _reactors bug', function () {
   it('doesnt happen any more', function () {
-    var $A = (0, _derivable.atom)(false);
-    var $B = (0, _derivable.atom)(false);
+    var $A = derivable.atom(false);
+    var $B = derivable.atom(false);
 
     var A_success = false;
     var C_success = false;
@@ -146,15 +141,15 @@ describe('the concurrent modification of _reactors bug', function () {
       from: $C
     });
 
-    _assert2.default.strictEqual(A_success, false);
-    _assert2.default.strictEqual(C_success, false);
+    assert.strictEqual(A_success, false);
+    assert.strictEqual(C_success, false);
     // used to be that this would cause the 'from' controller on C to be ignored
     // during the ._maybeReact iteration in .set
     $A.set(true);
-    _assert2.default.strictEqual(A_success, true);
-    _assert2.default.strictEqual(C_success, false);
+    assert.strictEqual(A_success, true);
+    assert.strictEqual(C_success, false);
     $B.set(true);
 
-    _assert2.default.strictEqual(C_success, true, "expecting c success");
+    assert.strictEqual(C_success, true, "expecting c success");
   });
 });


### PR DESCRIPTION
See [ES Observable spec draft](https://github.com/zenparsing/es-observable).

Interop is made via `symbol-observable` package. The same schema used in Redux
implementation. Test cases are adapted from Redux as well.

Any derivable is now observable, example code with Rx:

    import Rx from 'rxjs'
    import {atom} from 'derivable'

    let state = atom(42)

    Rx.Observable
      .from(state)
      .map(value => value * 2)
      .subscribe(value => console.log(value))

I think such interop attempt is useful, especiallu given that rxjs and redux adopts that schema as well (mobx has pending PR for that too). At least you can cherry pick the first commit which converts atom tests to readable code.