### PR TITLE
allow cyclic reactors as long as equilibrium is reached

### DIFF
--- a/src/reactors.js
+++ b/src/reactors.js
@@ -8,7 +8,7 @@ export function Reactor(parent, react, governor) {
   this.react = react;
   this._governor = governor || null;
   this._active = false;
-  this._reacting = false;
+  this._reacting = 0;
   this._type = types.REACTOR;
 
   if (util.DEBUG_MODE) {
@@ -28,7 +28,7 @@ util.assign(Reactor.prototype, {
 
   _force: function (nextValue) {
     try {
-      this._reacting = true;
+      this._reacting++;
       this.react(nextValue);
     } catch (e) {
       if (util.DEBUG_MODE) {
@@ -36,7 +36,7 @@ util.assign(Reactor.prototype, {
       }
       throw e;
     } finally {
-      this._reacting = false;
+      this._reacting--;
     }
   },
 
@@ -47,8 +47,8 @@ util.assign(Reactor.prototype, {
   },
 
   _maybeReact: function () {
-    if (!this._reacting && this._active) {
-      if (this._governor !== null) {
+    if (this._active) {
+    if (this._governor !== null) {
         this._governor._maybeReact();
       }
       // maybe the reactor was stopped by the parent

--- a/src/transactions.js
+++ b/src/transactions.js
@@ -23,8 +23,8 @@ export function mark (node, reactors) {
 export function processReactors (reactors) {
   for (var i = 0, len = reactors.length; i < len; i++) {
     var r = reactors[i];
-    if (r._reacting) {
-      throw new Error("Synchronous cyclical reactions disallowed. " +
+    if (r._reacting >= 10) {
+      throw new Error("Too deep synchronous cyclical reactions disallowed. " +
                       "Use setImmediate.");
     }
     r._maybeReact();

--- a/test/reactor_test.js
+++ b/test/reactor_test.js
@@ -441,7 +441,7 @@ describe("setting the values of atoms in a reaction phase", function () {
     });
   });
 
-  it("is not allowed if the atom in question is upstream of the reactor", function () {
+  it("is allowed if the atom in question is upstream of the reactor as long as equilibrium is reached", function () {
     var n = derivable.atom(3);
 
     // currently 1
@@ -453,15 +453,13 @@ describe("setting the values of atoms in a reaction phase", function () {
       return n * 2;
     };
 
-    var r = nmod2.react(function (_) {
+    nmod2.react(function (_) {
       return n.swap(double);
     }, {skipFirst: true});
 
-    assert.throws(function () {
-      return n.set(2);
-    });
-    // nmod2 becomes 0, reactor triggers n being set to 4
-    // reactor caught up in sweep again, identified as cycle
+    // nmod2 becomes 0, reactor triggers n being set to 4, nmod2 doesn't change and cycle stops
+    n.set(2);
+    assert.strictEqual(n.get(), 4);
   });
 });
 


### PR DESCRIPTION
This has been discussed before in #22 and #8 
Hopefully this proposed solution is something you can accept.

I'll try to describe the (simplified) use case why we need this:

1. we have a (client side) atom that defines which graphs (aka data sets) are in memory. This is initialised with an initial set.
1. we also have queries on this client side data set (aka derivables) that define which data sets should be available on the client
1. when the query for data sets returns new results, we fetch these graphs/data sets from the server and add these to the atom from the first step (a cyclic reactor)
1. once we add more data sets to the atom the derivable and reactor might trigger again as more data sets are needed. After 1 or 2 iterations this reaches an equilibrium 