### PR TITLE
derivable as arg to untill, from, and when functions in reactor options

### DIFF
--- a/derivable.d.ts
+++ b/derivable.d.ts
@@ -21,9 +21,9 @@ declare module derivable {
     mDerive<A, B, E>(f: (value: T, a: A, b: B) => E, a: (A | Derivable<A>), b: (B | Derivable<B>)): Derivable<E>;
     mDerive<E>(f: (value: T, ...args: any[]) => E, ...args: any[]): Derivable<E>;
 
-    react(f: (value: T) => void, options?: Lifecycle): void;
+    react(f: (value: T) => void, options?: Lifecycle<T>): void;
 
-    mReact(f: (value: T) => void, options?: Lifecycle): void;
+    mReact(f: (value: T) => void, options?: Lifecycle<T>): void;
 
     get(): T;
 
@@ -71,13 +71,13 @@ declare module derivable {
     set(value: T): void;
   }
 
-  export interface Lifecycle {
+  export interface Lifecycle<T> {
 
-    from?: ((() => boolean) | Derivable<boolean>);
+    from?: (((d: Derivable<T>) => boolean) | Derivable<boolean>);
 
-    when?: ((() => boolean) | Derivable<boolean>);
+    when?: (((d: Derivable<T>) => boolean) | Derivable<boolean>);
 
-    until?: ((() => boolean) | Derivable<boolean>);
+    until?: (((d: Derivable<T>) => boolean) | Derivable<boolean>);
 
     skipFirst?: boolean;
 

--- a/derivable.js.flow
+++ b/derivable.js.flow
@@ -19,9 +19,9 @@ export interface Derivable<T> {
   mDerive<A, B, E>(f: (value: $NonMaybeType<T>, a: A, b: B) => E, a: (A | Derivable<A>), b: (B | Derivable<B>)): Derivable<E>;
   mDerive<E>(f: (value: $NonMaybeType<T>, ...args: Array<mixed>) => E, ...args: Array<mixed>): Derivable<E>;
 
-  react(f: (value: T) => void, options?: Lifecycle): void;
+  react(f: (value: T) => void, options?: Lifecycle<T>): void;
 
-  mReact(f: (value: $NonMaybeType<T>) => void, options?: Lifecycle): void;
+  mReact(f: (value: $NonMaybeType<T>) => void, options?: Lifecycle<T>): void;
 
   get(): T;
 
@@ -69,13 +69,13 @@ export interface CompositeLens<T> {
   set(value: T): void;
 };
 
-export interface Lifecycle {
+export interface Lifecycle<T> {
 
-  from?: ((() => boolean) | Derivable<boolean>);
+  from?: (((d: Derivable<T>) => boolean) | Derivable<boolean>);
 
-  when?: ((() => boolean) | Derivable<boolean>);
+  when?: (((d: Derivable<T>) => boolean) | Derivable<boolean>);
 
-  until?: ((() => boolean) | Derivable<boolean>);
+  until?: (((d: Derivable<T>) => boolean) | Derivable<boolean>);
 
   skipFirst?: boolean;
 

--- a/src/reactors.js
+++ b/src/reactors.js
@@ -86,7 +86,7 @@ export function makeReactor (derivable, f, opts) {
   function condDerivable(fOrD, name) {
     if (!types.isDerivable(fOrD)) {
       if (typeof fOrD === 'function') {
-        return derivation(fOrD);
+        return derivation(function () { return fOrD(derivable); });
       } else if (typeof fOrD === 'boolean') {
         return derivation(function () { return fOrD; });
       } else {

--- a/test/reactor_test.js
+++ b/test/reactor_test.js
@@ -158,6 +158,68 @@ describe("anonymous reactors", function () {
     }
   });
 
+  it('can have `from`, `when`, and `until` specified as functions that use the derivable itself', function () {
+    {
+      (function () {
+        var a = derivable.atom('a');
+        var val = null;
+        a.react(function (a) {
+          val = a;
+        }, { when: function when(derivable) {
+            return derivable.get() > 'c';
+          } });
+
+        assert.strictEqual(val, null);
+
+        a.set('x');
+
+        assert.strictEqual(val, 'x');
+      })();
+    }
+    {
+      (function () {
+        var a = derivable.atom('a');
+        var val = null;
+        a.react(function (a) {
+          val = a;
+        }, { from: function from(derivable) {
+            return derivable.get() > 'c';
+          } });
+
+        assert.strictEqual(val, null);
+
+        a.set('x');
+
+        assert.strictEqual(val, 'x');
+      })();
+    }
+    {
+      (function () {
+        var a = derivable.atom('a');
+        var val = null;
+        a.react(function (a) {
+          val = a;
+        }, { until: function until(derivable) {
+            return derivable.is('b').get();
+          } });
+
+        assert.strictEqual(val, 'a');
+
+        a.set('c');
+
+        assert.strictEqual(val, 'c');
+
+        a.set('b');
+
+        assert.strictEqual(val, 'c');
+
+        a.set('a');
+
+        assert.strictEqual(val, 'c');
+      })();
+    }
+  });
+
   it('doesnt like it when `from`, `when`, and `until` are other things', function () {
     var a = derivable.atom('a');
     assert.throws(function () {


### PR DESCRIPTION
intentionally not giving derivable.get() to the function to prevent unnecessary registration of the functions as a derivable themselves if the function doesn't actually use the value. That's why I'm supplying the derivable itself and it is up to the function whether it invokes derivable.get() or not.

This PR is to implement #58 