### PR TITLE
Maybe derive returns always maybe type

### DIFF
--- a/derivable.js.flow
+++ b/derivable.js.flow
@@ -4,7 +4,7 @@ export interface Derivable<T> {
 
   derive<E>(f: (value: T) => E): Derivable<E>;
 
-  maybeDerive<E>(f: $NonMaybeType<T> => E): Derivable<E>;
+  maybeDerive<E>(f: $NonMaybeType<T> => E): Derivable<?E>;
 
   orDefault<E>(value: $NonMaybeType<E>): Derivable<$NonMaybeType<T> | E>;
 

--- a/test_flow/.flowconfig
+++ b/test_flow/.flowconfig
@@ -7,3 +7,4 @@
 
 [options]
 suppress_comment=\\(.\\|\\n\\)*\\$ExpectError
+include_warnings=true

--- a/test_flow/package.json
+++ b/test_flow/package.json
@@ -6,6 +6,6 @@
     "test": "flow check"
   },
   "devDependencies": {
-    "flow-bin": "^0.59.0"
+    "flow-bin": "^0.60.1"
   }
 }

--- a/test_flow/test_flow.js
+++ b/test_flow/test_flow.js
@@ -107,7 +107,7 @@ function testMaybeDeriveMethod() {
   const c = a.maybeDerive(v => v * 2);
   const d = b.maybeDerive(v => v * 2);
 
-  const e: number = c.get();
+  const e: ?number = c.get();
 
   // $ExpectError
   const f: string = c.get();

--- a/test_flow/yarn.lock
+++ b/test_flow/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-flow-bin@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+flow-bin@^0.60.1:
+  version "0.60.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.60.1.tgz#0f4fa7b49be2a916f18cd946fc4a51e32ffe4b48"


### PR DESCRIPTION
I guess I skipped a lot of errors since flow warn on suppressed errors. Now maybeDerive always return nullable value.
/cc @andreypopp 