### PR TITLE
Proposal: Remove transact and transaction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,13 +8,7 @@ import { assign, setDebugMode } from "./util";
 
 export { isDerivable, isAtom, isProxy, isDerivation } from "./types";
 export { unpack, struct } from "./unpack.js";
-export {
-  transact,
-  transaction,
-  ticker,
-  atomic,
-  atomically
-} from "./transactions";
+export { ticker, atomic, atomically } from "./transactions";
 
 export { atom, proxy, derive, setDebugMode };
 

--- a/src/transactions.js
+++ b/src/transactions.js
@@ -59,7 +59,7 @@ export function inTransaction() {
   return currentCtx !== null;
 }
 
-export function transact(f) {
+function transact(f) {
   beginTransaction();
   try {
     f(initiateAbortion);
@@ -79,16 +79,6 @@ export function atomically(f) {
   } else {
     f();
   }
-}
-
-export function transaction(f) {
-  return (...args) => {
-    let result;
-    transact(() => {
-      result = f(...args);
-    });
-    return result;
-  };
 }
 
 export function atomic(f) {


### PR DESCRIPTION
Now we have a lot of ways to do transaction. I'd like to figure out is there a use case in transact/transaction functions over atomic/atomically?

/cc @ds300 @andreypopp 