### PR TITLE
Add support for meta parameter in atom, derive, proxy factories

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "es5/no-rest-parameters": 0,
     "es5/no-template-literals": 0,
     "es5/no-spread": 0,
-    "es5/no-destructuring": 0
+    "es5/no-destructuring": 0,
+    "es5/no-default-parameters": 0
   }
 }

--- a/src/atom.js
+++ b/src/atom.js
@@ -7,13 +7,14 @@ import global from "./global";
 
 const devtoolsHook = global.__DERIVABLE_DEVTOOLS_HOOK__;
 
-export function Atom(value) {
+export function Atom(value, meta = null) {
   this._id = util.nextId();
   this._activeChildren = [];
   this._value = value;
   this._state = UNCHANGED;
   this._type = ATOM;
   this._equals = null;
+  this._meta = meta;
 }
 
 util.assign(Atom.prototype, {
@@ -50,6 +51,6 @@ util.assign(Atom.prototype, {
   }
 });
 
-export function atom(value) {
-  return new Atom(value);
+export function atom(value, meta) {
+  return new Atom(value, meta);
 }

--- a/src/derivation.js
+++ b/src/derivation.js
@@ -3,7 +3,7 @@ import * as parents from "./parents";
 import * as types from "./types";
 import { CHANGED, UNCHANGED, UNKNOWN, DISCONNECTED } from "./states";
 
-export function Derivation(deriver) {
+export function Derivation(deriver, meta = null) {
   this._deriver = deriver;
   this._parents = null;
   this._type = types.DERIVATION;
@@ -11,6 +11,7 @@ export function Derivation(deriver) {
   this._equals = null;
   this._activeChildren = [];
   this._state = DISCONNECTED;
+  this._meta = meta;
 
   if (util.isDebug()) {
     this.stack = Error().stack;
@@ -116,9 +117,9 @@ export function detach(parent, child) {
   }
 }
 
-export function derive(f) {
+export function derive(f, meta) {
   if (typeof f !== "function") {
     throw Error("derive requires function");
   }
-  return new Derivation(f);
+  return new Derivation(f, meta);
 }

--- a/src/lens.js
+++ b/src/lens.js
@@ -3,8 +3,8 @@ import * as types from "./types";
 import { Derivation } from "./derivation";
 import { atomically } from "./transactions";
 
-export function Lens(descriptor) {
-  Derivation.call(this, descriptor.get);
+export function Lens(descriptor, meta) {
+  Derivation.call(this, descriptor.get, meta);
   this._descriptor = descriptor;
   this._type = types.LENS;
 }
@@ -21,6 +21,6 @@ util.assign(Lens.prototype, Derivation.prototype, {
   }
 });
 
-export function lens(descriptor) {
-  return new Lens(descriptor);
+export function lens(descriptor, meta) {
+  return new Lens(descriptor, meta);
 }


### PR DESCRIPTION
One more thing for devtools to make babel processing simpler.

Example

```js
const myAtom = atom(1, {
  displayName: 'myAtom'
});
```

/cc @ds300 @andreypopp 